### PR TITLE
add commenting preferences so that comment shortcuts (e.g. crtl+/) work

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>scope</key>
+  <string>source.modelica</string>
+  <key>settings</key>
+  <dict>
+    <key>shellVariables</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START</string>
+        <key>value</key>
+        <string>// </string>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_START_2</string>
+        <key>value</key>
+        <string>/*</string>
+      </dict>
+      <dict>
+        <key>name</key>
+        <string>TM_COMMENT_END_2</string>
+        <key>value</key>
+        <string>*/</string>
+      </dict>
+    </array>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
The comment shortcut was not working, so I added the missing file.